### PR TITLE
added logic to support nvim-possession if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Modules And Plugins supported
 
 - [possession](https://github.com/jedrzejboczar/possession.nvim)
 
+- [nvim-possession](https://github.com/gennaro-tedesco/nvim-possession)
+
 :zap: Requirements
 ------------------
 

--- a/lua/linefly/plugins.lua
+++ b/lua/linefly/plugins.lua
@@ -54,7 +54,9 @@ M.status = function()
     -- Obsession plugin.
     session_segment = eval([[ObsessionStatus('obsession', '!obsession')]])
   elseif options().with_session_status and package.loaded.possession then
-    session_segment = require('possession.session').session_name
+    session_segment = require("possession.session").session_name
+  elseif options().with_session_status and package.loaded["nvim-possession"] then
+    session_segment = require("nvim-possession").status()
   end
   if is_present(session_segment) then
     segments = segments .. " %#LineflySession#" .. session_segment .. "%*"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Spaces"
+indent_width = 2
+column_width = 120


### PR DESCRIPTION
- Add support for [nvim-possession](https://github.com/gennaro-tedesco/nvim-possession)

The statusline will then look like the following:
![Screenshot 2023-01-20 at 10 43 51](https://user-images.githubusercontent.com/15387611/213667119-6e274a7a-2d9c-4a35-adc7-1dc4d9b11fae.png)

P. S. I have added a `stylua.toml` because my formatting did not coincide with yours, to avoid a `git diff` of the entire file. You can remove such file if you have your own in place. 

