### PR TITLE
Fixed init errors if linefly_options is nil

### DIFF
--- a/lua/linefly/options.lua
+++ b/lua/linefly/options.lua
@@ -5,6 +5,9 @@ local M = {}
 
 M.list = function()
   if not options_initialized then
+    if g.linefly_options == nil then
+      g.linefly_options = {}
+    end
     g.linefly_options = {
       separator_symbol = g.linefly_options.separator_symbol or "⎪",
       progress_symbol = g.linefly_options.progress_symbol or "↓",


### PR DESCRIPTION
Error detected while processing BufWinEnter Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	....local/share/nvim/lazy/nvim-linefly/lua/linefly/init.lua:110: in function 'statusline'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:47: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:46>
Error detected while processing BufEnter Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	.../.local/share/nvim/lazy/nvim-linefly/lua/linefly/git.lua:41: in function 'detect_branch_name'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:63: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:60>
Error detected while processing VimEnter Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	...l/share/nvim/lazy/nvim-linefly/lua/linefly/highlight.lua:176: in function 'generate_groups'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:26: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:25>
Error detected while processing VimEnter Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	....local/share/nvim/lazy/nvim-linefly/lua/linefly/init.lua:175: in function 'tabline'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:40: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:39>
E5108: Error executing lua ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	....local/share/nvim/lazy/nvim-linefly/lua/linefly/init.lua:58: in function <....local/share/nvim/lazy/nvim-linefly/lua/linefly/init.lua:56>
Error detected while processing FocusGained Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	.../.local/share/nvim/lazy/nvim-linefly/lua/linefly/git.lua:41: in function 'detect_branch_name'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:63: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:60>
Error detected while processing FocusGained Autocommands for "*": Error executing lua callback: ...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: attempt to index field 'linefly_options' (a nil value) stack traceback:
	...cal/share/nvim/lazy/nvim-linefly/lua/linefly/options.lua:9: in function 'options'
	.../.local/share/nvim/lazy/nvim-linefly/lua/linefly/git.lua:41: in function 'detect_branch_name'
	...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:63: in function <...h/.local/share/nvim/lazy/nvim-linefly/plugin/linefly.lua:60>